### PR TITLE
Make LVM Volume Group configurable

### DIFF
--- a/lxc/.lxc-template/config
+++ b/lxc/.lxc-template/config
@@ -1,4 +1,4 @@
-lxc.rootfs = /dev/vg/++NAME++
+lxc.rootfs = /dev/++VG++/++NAME++
 lxc.utsname = ++NAME++
 
 lxc.network.type = veth

--- a/lxc/lxc-create-gentoo
+++ b/lxc/lxc-create-gentoo
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 usage() {
-	echo "$0: [-h] [-K] [-k keyfile] [-u user-data]"
+	echo "$0: [-h] [-K] [-k keyfile] [-u user-data] [-V vol_gr]"
 }
 
 _abspath() {
@@ -26,6 +26,10 @@ do
 		;;
 	-u)
 		USER_DATA+="$(_abspath "$2")"
+		shift 2
+		;;
+	-V)
+		vg="$2"
 		shift 2
 		;;
 	-h)
@@ -54,16 +58,16 @@ echo "Creating container: $uts"
 MAC=$(openssl rand -hex 6|sed 's/\(xx\)/\1:/g; s/.$//')
 cd "$LXC_ROOT"
 mkdir -p "${LXC_ROOT}/${uts}/rootfs"
-sed "s/++NAME++/${uts}/; s/++MAC++/${MAC}/;" \
+sed "s/++NAME++/${uts}/; s/++MAC++/${MAC}/; s/++VG++/${vg:=vg}/;" \
     "${LXC_ROOT}/.lxc-template/config" > "${LXC_ROOT}/${uts}/config"
 
-lvcreate -s vg/lxc-clean -n "${uts}" -L 10G
+lvcreate -s ${vg}/lxc-clean -n "${uts}" -L 10G
 
 ############################
 # Modify the container
 ############################
 mountdir=$(mktemp -d)
-mount "/dev/vg/${uts}" $mountdir
+mount "/dev/${vg}/${uts}" $mountdir
 test x"$SSH_KEYS" = "x" || \
 	cp "$SSH_KEYS"  $mountdir/etc/local.d/openssh-key
 test x"$USER_DATA" = "x" || \
@@ -83,6 +87,6 @@ lxc-start -n "${uts}"
 test _"$KEEP_AFTER_STOP" = _y && {
     echo "Not destroying container: ${uts}"
 } || {
-    lvremove -f "vg/${uts}"
+    lvremove -f "${vg}/${uts}"
     rm -rvf "${LXC_ROOT}/${uts}"
 }


### PR DESCRIPTION
Currently using hard-coded LVM Volume Group called 'vg'.

Allow use of VG starting with 'vg_', but still defaulting to 'vg' if not given.

Note: doesn't allow use of VG starting with 'vg'.
